### PR TITLE
Fixed tiny spelling error

### DIFF
--- a/docs/performance_guide.md
+++ b/docs/performance_guide.md
@@ -127,7 +127,7 @@ class TestTeleOp extends LinearOpMode {
         // change the number
 
         for(PhotonLynxModule module: modules)
-            modules.setBulkCachingMode(BulkCachingMode.MANUAL); // Manual mode is required here
+            module.setBulkCachingMode(BulkCachingMode.MANUAL); // Manual mode is required here
         
         //...
         


### PR DESCRIPTION
Tiny spelling error in the documentation for manual bulk caching.