### PR TITLE
Fixed documentation at the README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ maven { url = 'https://jitpack.io' }
 Then add the following under dependencies
 
 ```
-implementation 'com.github.Eeshwar-Krishnan:PhotonFTC:v2.0.0-Alpha'
+implementation 'com.github.Eeshwar-Krishnan:PhotonFTC:v3.0.0-ALPHA'
 ```
 
 Then run a gradle sync, and everything should download!


### PR DESCRIPTION
The implementation line was out dated was:
```implementation 'com.github.Eeshwar-Krishnan:PhotonFTC:v2.0.0-Alpha'```

should have been:
```implementation 'com.github.Eeshwar-Krishnan:PhotonFTC:v3.0.0-ALPHA'```

As it is the most recent according to the jitpack:
```https://jitpack.io/#Eeshwar-Krishnan/PhotonFTC/```